### PR TITLE
Fix duplicated conditions the checkFileName

### DIFF
--- a/src/interfaces/handler.php
+++ b/src/interfaces/handler.php
@@ -136,7 +136,7 @@ abstract class ezcImageHandler
      */
     protected function checkFileName( $file )
     {
-        if ( strpos( $file, "'" ) !== false || strpos( $file, "'" ) !== false || strpos( $file, '$' ) !== false )
+        if ( strpos( $file, "'" ) !== false || strpos( $file, '"' ) !== false || strpos( $file, '$' ) !== false )
         {
             throw new ezcImageFileNameInvalidException( $file );
         }


### PR DESCRIPTION
The illegal character " was not included in the verification because of duplicated conditions